### PR TITLE
Use hmac.compare_digests to compare password digests instead of == to prevent the risk of a timing attack

### DIFF
--- a/motorengine/fields/password_field.py
+++ b/motorengine/fields/password_field.py
@@ -1,5 +1,6 @@
 import six
 import hashlib
+import hmac
 
 from motorengine.fields.base_field import BaseField
 
@@ -43,9 +44,9 @@ class PasswordType:
 
     def __eq__(self, other):
         if isinstance(other, six.string_types):
-            return self.crypt_func(other) == self.value
+            return hmac.compare_digest(self.crypt_func(other), self.value)
         elif isinstance(other, PasswordType):
-            return self.value == other.value
+            return hmac.compare_digest(self.value, other.value)
         return False
 
     def __ne__(self, other):


### PR DESCRIPTION
The equality comparisons of the `PasswordType` used by `PasswordField` used `==` for comparison, leaving the password at risk of a [timing attack](https://codahale.com/a-lesson-in-timing-attacks/). This PR replaces this comparison with [`hmac.compare_digest`](https://docs.python.org/3/library/hmac.html#hmac.compare_digest), the suggested alternative in the stdlib.